### PR TITLE
remove latte

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
 		"nette/safe-stream": "~2.3.0",
 		"nette/security": "~2.3.0",
 		"nette/utils": "~2.3.0",
-		"latte/latte": "~2.3.0",
 		"tracy/tracy": "~2.3.0",
 		"dg/adminer-custom": "~1.6",
 		"kdyby/doctrine": "~3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ad29a214e97e12b442a149306629b82f",
+    "content-hash": "f514a2aeb54d81612331f4d70ce15102",
     "packages": [
         {
             "name": "dg/adminer-custom",
@@ -1046,61 +1046,6 @@
                 "nette"
             ],
             "time": "2015-10-30T18:00:28+00:00"
-        },
-        {
-            "name": "latte/latte",
-            "version": "v2.3.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/latte.git",
-                "reference": "3140733d6ab0531b25500cb2f2e7c4abbfa5d725"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/latte/zipball/3140733d6ab0531b25500cb2f2e7c4abbfa5d725",
-                "reference": "3140733d6ab0531b25500cb2f2e7c4abbfa5d725",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=5.3.1"
-            },
-            "require-dev": {
-                "nette/tester": "~1.3"
-            },
-            "suggest": {
-                "ext-fileinfo": "to use filter |datastream",
-                "ext-mbstring": "to use filters like lower, upper, capitalize, ..."
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0",
-                "GPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "Latte: the amazing template engine for PHP",
-            "homepage": "https://latte.nette.org",
-            "keywords": [
-                "templating",
-                "twig"
-            ],
-            "time": "2015-12-02T22:05:24+00:00"
         },
         {
             "name": "nette/application",
@@ -2261,5 +2206,6 @@
     "platform": {
         "php": ">= 5.6.0"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
Ve starší verzi latte je nějaká zranitelnost (https://github.com/neogenia/mvcr-street-api/security/dependabot/composer.lock/latte%2Flatte/open). Latte se tady nijak nepoužívá, mažu.